### PR TITLE
update dockerfile for node10 for npm ci niceties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER root
 
 # add NodeJS and Chrome sources
 RUN apt-get install -y curl \
-    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && curl -sL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list
 
@@ -20,10 +20,10 @@ RUN apt update \
     firefox-esr
 
 #Roll back to npm 4 for certain polymer-cli version issues. This should no longer be necessary
-RUN npm install -g npm@4 
+RUN npm install -g npm 
 
-# install Polymer cli (with web-component-tester) & bower globally, keep gulp for fancy tasks.
-RUN npm install -g gulp-cli gulp bower polymer-cli && echo '{ "allow_root": true }' > /root/.bowerrc
+# install Polymer cli (with web-component-tester) & bower globally, keep gulp for fancy tasks. keep bower for the time being. (you shouldn't be using it)
+RUN npm install -g --unsafe-perm gulp-cli gulp bower polymer-cli && echo '{ "allow_root": true }' > /root/.bowerrc
 
 #try to fool google-chrome to run without sandbox - from https://github.com/printminion/polymer-tester
 RUN mv /usr/bin/google-chrome /usr/bin/google-chrome-orig \


### PR DESCRIPTION
This will update the dockerfile for node 10 and npm 6+.

For those who don't know, npm 5+ comes with a handy `npm ci` command which is drastically faster than running npm install and speeds up automated builds significantly.

Kept bower for backwards compatibility.